### PR TITLE
feat: add optional Vault server deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,28 @@ spec:
 
 </details>
 
+<details><summary><b>DEPLOY VAULT SERVER WITH CSI PROVIDER</b></summary>
+
+```hcl
+module "vault-base-setup" {
+  source                 = "github.com/stuttgart-things/vault-base-setup"
+  vault_addr             = "https://vault.demo-infra.example.com"
+  cluster_name           = "kind-dev2"
+  context                = "kind-dev2"
+  skip_tls_verify        = true
+  kubeconfig_path        = "/home/sthings/.kube/kind-dev2"
+  vault_enabled          = true
+  vault_dev_mode         = true
+  vault_injector_enabled = false
+  vault_csi_enabled      = true
+  namespace_vault        = "vault"
+  csi_enabled            = false
+  vso_enabled            = false
+}
+```
+
+</details>
+
 <details><summary><b>CSI PROVIDER EXAMPLE APPLICATION</b></summary>
 
 ### SecretProviderClass

--- a/variables.tf
+++ b/variables.tf
@@ -161,6 +161,36 @@ variable "skip_tls_verify" {
   default     = false
 }
 
+variable "vault_enabled" {
+  description = "Enable Vault server deployment"
+  type        = bool
+  default     = false
+}
+
+variable "namespace_vault" {
+  description = "Namespace for Vault server deployment"
+  type        = string
+  default     = "vault"
+}
+
+variable "vault_dev_mode" {
+  description = "Enable Vault dev mode"
+  type        = bool
+  default     = true
+}
+
+variable "vault_injector_enabled" {
+  description = "Enable Vault injector"
+  type        = bool
+  default     = false
+}
+
+variable "vault_csi_enabled" {
+  description = "Enable Vault CSI provider"
+  type        = bool
+  default     = true
+}
+
 # Whether Helm should wait for resources to become ready
 variable "vso_wait" {
   description = "Whether to wait for resources to be ready before marking the Helm release as successful."

--- a/vault.tf
+++ b/vault.tf
@@ -1,0 +1,26 @@
+// DEPLOY VAULT SERVER
+resource "helm_release" "vault" {
+  count            = var.vault_enabled ? 1 : 0
+  name             = "vault"
+  namespace        = var.namespace_vault
+  create_namespace = true
+  repository       = "https://helm.releases.hashicorp.com"
+  chart            = "vault"
+  version          = "0.29.1"
+  atomic           = true
+  timeout          = 240
+
+  values = [yamlencode({
+    server = {
+      dev = {
+        enabled = var.vault_dev_mode
+      }
+    }
+    injector = {
+      enabled = var.vault_injector_enabled
+    }
+    csi = {
+      enabled = var.vault_csi_enabled
+    }
+  })]
+}


### PR DESCRIPTION
## Summary
- Add optional Vault server Helm deployment with configurable dev mode, injector, and CSI provider
- New variables: `vault_enabled`, `namespace_vault`, `vault_dev_mode`, `vault_injector_enabled`, `vault_csi_enabled`
- Disabled by default (`vault_enabled = false`) so existing usage is unaffected
- Add usage example to README

Closes #2

## Test plan
- [ ] Verify `terraform validate` passes (confirmed locally)
- [ ] Test with `vault_enabled = true` to deploy Vault server
- [ ] Test with `vault_csi_enabled = true` to enable CSI provider
- [ ] Verify existing functionality is unaffected when `vault_enabled = false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)