### PR TITLE
feat: add Vault PKI CA with cert-manager integration

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: vault-base-setup
+  description: Terraform module for base-setup configuration of HashiCorp Vault
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+    github.com/project-slug: stuttgart-things/vault-base-setup
+  tags:
+    - terraform
+    - vault
+    - pki
+    - cert-manager
+spec:
+  type: library
+  lifecycle: production
+  owner: stuttgart-things

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,51 @@
+# vault-base-setup
+
+Terraform module for base-setup configuration of HashiCorp Vault.
+
+## Features
+
+| Feature | Variable | Description |
+|---------|----------|-------------|
+| KV Secrets Engines | `secret_engines` | Mount KV v2 secrets engines and write initial secrets |
+| KV Policies | `kv_policies` | Create ACL policies for KV access |
+| Kubernetes Auth | `k8s_auths` | Configure Kubernetes auth backends for service account authentication |
+| AppRole Auth | `enableApproleAuth`, `approle_roles` | Enable AppRole auth with configurable roles |
+| UserPass Auth | `enableUserPass`, `user_list` | Enable username/password authentication |
+| CSI Provider | `csi_enabled` | Deploy Secrets Store CSI Driver integration |
+| VSO | `vso_enabled` | Deploy Vault Secrets Operator |
+| Vault Server | `vault_enabled` | Deploy Vault server via Helm |
+| **PKI CA** | `pki_enabled` | Mount PKI secrets engine with root CA for cert-manager integration |
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.10.5 |
+| vault provider | >= 3.21.0 |
+| kubernetes provider | >= 2.24.0 |
+| helm provider | >= 2.12.1 |
+
+## Quick Start
+
+```hcl
+module "vault-base-setup" {
+  source          = "github.com/stuttgart-things/vault-base-setup"
+  vault_addr      = "https://vault.example.com"
+  skip_tls_verify = true
+  kubeconfig_path = "/path/to/kubeconfig"
+  cluster_name    = "my-cluster"
+  csi_enabled     = false
+  vso_enabled     = false
+}
+```
+
+## Authentication
+
+The module authenticates to Vault using the `VAULT_TOKEN` environment variable:
+
+```bash
+export VAULT_ADDR=https://vault.example.com
+export VAULT_TOKEN=hvs.<token>
+terraform init
+terraform apply
+```

--- a/docs/pki-ca.md
+++ b/docs/pki-ca.md
@@ -1,0 +1,259 @@
+# PKI CA with cert-manager
+
+This guide covers setting up Vault as a PKI Certificate Authority and integrating it with cert-manager for automated certificate issuance across Kubernetes clusters.
+
+## Architecture
+
+```text
++-------------------+         +-------------------+         +-------------------+
+|  Terraform        |         |  Vault (Cluster A)|         | cert-manager      |
+|  vault-base-setup | ------> |  PKI Engine       | <------ | (Cluster B)       |
+|                   |         |  Root CA          |         | ClusterIssuer     |
+|  pki_enabled=true |         |  Roles + Policy   |         | Certificate       |
++-------------------+         +-------------------+         +-------------------+
+```
+
+The PKI engine runs on the Vault instance. cert-manager can run on the same or a different cluster and connects to Vault via its ingress URL.
+
+## Step 1: Deploy PKI Engine with Terraform
+
+```hcl
+module "vault-base-setup" {
+  source          = "github.com/stuttgart-things/vault-base-setup"
+  vault_addr      = "https://vault.demo-infra.sthings-vsphere.labul.sva.de"
+  skip_tls_verify = true
+  kubeconfig_path = "/home/sthings/.kube/demo-infra"
+  cluster_name    = "demo-infra"
+
+  csi_enabled = false
+  vso_enabled = false
+
+  # PKI CA configuration
+  pki_enabled      = true
+  pki_path         = "pki"
+  pki_common_name  = "sthings-vsphere.labul.sva.de"
+  pki_organization = "sva"
+  pki_country      = "DE"
+  pki_key_type     = "rsa"
+  pki_key_bits     = 2048
+  pki_root_ttl     = "87600h"
+
+  pki_roles = [
+    {
+      name             = "sthings-vsphere"
+      allowed_domains  = ["sthings-vsphere.labul.sva.de"]
+      allow_subdomains = true
+      max_ttl          = "720h"
+    }
+  ]
+}
+```
+
+Apply the configuration:
+
+```bash
+export VAULT_TOKEN=hvs.<root-token>
+terraform init
+terraform apply
+```
+
+### What Gets Created
+
+| Resource | Path / Name | Purpose |
+|----------|-------------|---------|
+| PKI Mount | `pki/` | PKI secrets engine |
+| Root CA | `pki/issuer/...` | Self-signed root certificate |
+| URL Config | `pki/config/urls` | CA and CRL distribution endpoints |
+| Role | `pki/roles/sthings-vsphere` | Certificate issuance role with domain constraints |
+| Policy | `pki-issue` | ACL policy granting issue/sign/read capabilities |
+
+### PKI Variables Reference
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `pki_enabled` | bool | `false` | Enable PKI secrets engine |
+| `pki_path` | string | `"pki"` | Mount path |
+| `pki_common_name` | string | `"example.com"` | Root CA common name |
+| `pki_organization` | string | `""` | Root CA organization |
+| `pki_country` | string | `""` | Root CA country |
+| `pki_type` | string | `"internal"` | Root cert type (`internal` or `exported`) |
+| `pki_key_type` | string | `"rsa"` | Key algorithm (`rsa` or `ec`) |
+| `pki_key_bits` | number | `2048` | Key size (2048/4096 for RSA, 256/384 for EC) |
+| `pki_root_ttl` | string | `"87600h"` | Root CA lifetime (default 10 years) |
+| `pki_default_ttl_seconds` | number | `3600` | Default lease TTL |
+| `pki_max_ttl_seconds` | number | `315360000` | Max lease TTL |
+| `pki_policy_name` | string | `"pki-issue"` | Name of the ACL policy |
+| `pki_roles` | list(object) | `[]` | Certificate issuance roles |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `pki_ca_cert` | Root CA certificate in PEM format |
+| `pki_path` | PKI engine mount path |
+| `pki_roles` | List of created role names |
+
+## Step 2: Verify PKI Engine
+
+After applying, verify the PKI engine is working by issuing a test certificate via the Vault API:
+
+```bash
+curl -sk \
+  --header "X-Vault-Token: $VAULT_TOKEN" \
+  --request POST \
+  --data '{"common_name": "test.sthings-vsphere.labul.sva.de", "ttl": "24h"}' \
+  $VAULT_ADDR/v1/pki/issue/sthings-vsphere
+```
+
+## Step 3: Create a Vault Token for cert-manager
+
+Create a token scoped to the `pki-issue` policy:
+
+```bash
+curl -sk \
+  --header "X-Vault-Token: $VAULT_TOKEN" \
+  --request POST \
+  --data '{"policies": ["pki-issue"], "ttl": "720h"}' \
+  $VAULT_ADDR/v1/auth/token/create
+```
+
+Store the token as a Kubernetes secret in the cert-manager namespace on the target cluster:
+
+```bash
+kubectl create secret generic vault-pki-token \
+  --namespace cert-manager \
+  --from-literal=token="hvs.<pki-token>"
+```
+
+## Step 4: Retrieve the Vault Ingress CA Certificate
+
+When Vault is exposed via an ingress with a TLS certificate signed by a private CA (which is common in on-prem environments), cert-manager must trust that CA to establish a connection. Without it, the ClusterIssuer will fail with:
+
+```text
+Failed to verify Vault is initialized and unsealed:
+tls: failed to verify certificate: x509: certificate signed by unknown authority
+```
+
+### Retrieve the CA certificate
+
+**Option A** - Extract from the TLS secret on the Vault cluster:
+
+```bash
+kubectl get secret <vault-ingress-tls-secret> \
+  -n vault \
+  -o jsonpath='{.data.ca\.crt}'
+```
+
+This outputs the base64-encoded CA certificate directly, ready for the `caBundle` field.
+
+**Option B** - Extract from the live TLS connection (requires the full chain):
+
+```bash
+# Get the issuer CA, not the leaf certificate
+openssl s_client -connect vault.example.com:443 \
+  -servername vault.example.com -showcerts 2>/dev/null \
+  | awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' \
+  | base64 -w0
+```
+
+**Important:** The `caBundle` field requires the **issuing CA certificate** (the certificate that signed the ingress TLS cert), not the leaf/server certificate itself. Using the leaf certificate will result in:
+
+```text
+cert bundle didn't contain any valid certificates
+```
+
+## Step 5: Create the ClusterIssuer
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: vault-pki
+spec:
+  vault:
+    path: pki/sign/sthings-vsphere
+    server: https://vault.demo-infra.sthings-vsphere.labul.sva.de
+    caBundle: <base64-encoded-ca-certificate>
+    auth:
+      tokenSecretRef:
+        name: vault-pki-token
+        key: token
+```
+
+The `caBundle` contains the base64-encoded PEM of the CA that signed the Vault ingress TLS certificate. The token secret must exist in the cert-manager controller's `--cluster-resource-namespace` (defaults to the cert-manager pod's namespace).
+
+Verify the issuer is ready:
+
+```bash
+kubectl get clusterissuer vault-pki
+# NAME        READY   AGE
+# vault-pki   True    9s
+```
+
+## Step 6: Request a Certificate
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-app-tls
+  namespace: default
+spec:
+  secretName: my-app-tls
+  issuerRef:
+    name: vault-pki
+    kind: ClusterIssuer
+  commonName: myapp.sthings-vsphere.labul.sva.de
+  dnsNames:
+    - myapp.sthings-vsphere.labul.sva.de
+  duration: 720h
+  renewBefore: 24h
+```
+
+Verify the certificate was issued:
+
+```bash
+kubectl get certificate my-app-tls
+# NAME         READY   SECRET       AGE
+# my-app-tls   True    my-app-tls   10s
+```
+
+Inspect the issued certificate:
+
+```bash
+kubectl get secret my-app-tls -o jsonpath='{.data.tls\.crt}' \
+  | base64 -d \
+  | openssl x509 -noout -subject -issuer -dates
+# subject=CN=myapp.sthings-vsphere.labul.sva.de
+# issuer=C=DE, O=sva, CN=sthings-vsphere.labul.sva.de
+# notBefore=...
+# notAfter=...
+```
+
+## Troubleshooting
+
+### ClusterIssuer shows `VaultError` with TLS failure
+
+```text
+tls: failed to verify certificate: x509: certificate signed by unknown authority
+```
+
+The `caBundle` is missing or does not contain the correct CA. See [Step 4](#step-4-retrieve-the-vault-ingress-ca-certificate).
+
+### ClusterIssuer rejected with "cert bundle didn't contain any valid certificates"
+
+You are providing the leaf/server certificate instead of the issuing CA certificate. Extract the CA cert from the Vault cluster's TLS secret (`ca.crt` key) rather than from the live TLS connection's first certificate.
+
+### Certificate stays in `Pending` state
+
+Check the CertificateRequest and Order status:
+
+```bash
+kubectl describe certificaterequest -n <namespace>
+```
+
+Common causes:
+
+- The Vault token has expired - create a new one and update the secret
+- The PKI role does not allow the requested domain - check `allowed_domains` and `allow_subdomains`
+- The requested TTL exceeds the role's `max_ttl`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: vault-base-setup
+site_description: Terraform module for base-setup configuration of HashiCorp Vault
+repo_url: https://github.com/stuttgart-things/vault-base-setup
+
+nav:
+  - Overview: index.md
+  - PKI CA with cert-manager: pki-ca.md
+
+plugins:
+  - techdocs-core

--- a/tests/pki-test.tf
+++ b/tests/pki-test.tf
@@ -1,0 +1,54 @@
+terraform {
+  required_version = ">= 1.10.5"
+}
+
+module "vault-pki-test" {
+  source          = "../"
+  vault_addr      = "https://vault.demo-infra.sthings-vsphere.labul.sva.de"
+  skip_tls_verify = true
+  kubeconfig_path = "/home/sthings/.kube/demo-infra"
+  cluster_name    = "demo-infra"
+
+  # Disable features we don't need for this test
+  csi_enabled              = false
+  vso_enabled              = false
+  enableApproleAuth        = false
+  createDefaultAdminPolicy = false
+  enableUserPass           = false
+  vault_enabled            = false
+
+  # PKI CA configuration
+  pki_enabled      = true
+  pki_path         = "pki"
+  pki_common_name  = "sthings-vsphere.labul.sva.de"
+  pki_organization = "sva"
+  pki_country      = "DE"
+  pki_key_type     = "rsa"
+  pki_key_bits     = 2048
+  pki_root_ttl     = "87600h"
+
+  pki_roles = [
+    {
+      name             = "sthings-vsphere"
+      allowed_domains  = ["sthings-vsphere.labul.sva.de"]
+      allow_subdomains = true
+      max_ttl          = "720h"
+    }
+  ]
+}
+
+output "pki_ca_cert" {
+  description = "PKI root CA certificate"
+  value       = module.vault-pki-test.pki_ca_cert
+  sensitive   = true
+}
+
+output "pki_path" {
+  description = "PKI secrets engine mount path"
+  value       = module.vault-pki-test.pki_path
+}
+
+output "pki_roles" {
+  description = "Created PKI role names"
+  value       = module.vault-pki-test.pki_roles
+}


### PR DESCRIPTION
## Summary
- Add Vault PKI secrets engine support (`pki_enabled`) for generating a root CA, configurable roles, and ACL policies
- Add Backstage-compatible TechDocs (`mkdocs.yml`, `catalog-info.yaml`, `docs/`) documenting the full PKI CA + cert-manager workflow
- Document the Vault ingress CA certificate requirement for ClusterIssuer `caBundle` (leaf cert vs issuing CA gotcha)
- Add PKI integration test config (`tests/pki-test.tf`)

## Test plan
- [x] Terraform apply creates PKI engine, root CA, role, and policy on demo-infra Vault
- [x] Test certificate issued successfully via Vault API
- [x] ClusterIssuer on vre2 cluster reaches Vault with correct `caBundle`
- [x] cert-manager Certificate resource issued and signed by Vault CA
- [ ] Verify TechDocs render correctly in Backstage

🤖 Generated with [Claude Code](https://claude.com/claude-code)