### PR TITLE
feat: add Dagger module for ephemeral Vault terraform-apply tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Dagger generated artifacts
+dagger/.dagger/
+dagger/go.sum

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -80,6 +80,24 @@ tasks:
       - gh pr merge $(gh pr list | grep "^[^#;]" | grep '{{ .BRANCH }}' | awk '{print $1}') --auto --rebase --delete-branch
       - git checkout main && git pull
 
+  dagger:test-dev:
+    desc: Run terraform apply against an ephemeral Vault dev-mode container via Dagger
+    dir: dagger
+    cmds:
+      - dagger call test-terraform-apply-dev
+
+  dagger:test-tls:
+    desc: Run terraform apply against an ephemeral TLS-enabled Vault (init + unseal) via Dagger
+    dir: dagger
+    cmds:
+      - dagger call test-terraform-apply-tls
+
+  dagger:test:
+    desc: Run both Dagger terraform-apply tests
+    deps:
+      - dagger:test-dev
+      - dagger:test-tls
+
   run-pre-commit-hook:
     deps:
       - check

--- a/dagger/.gitattributes
+++ b/dagger/.gitattributes
@@ -1,0 +1,4 @@
+/dagger.gen.go linguist-generated
+/internal/dagger/** linguist-generated
+/internal/querybuilder/** linguist-generated
+/internal/telemetry/** linguist-generated

--- a/dagger/.gitignore
+++ b/dagger/.gitignore
@@ -1,0 +1,5 @@
+/dagger.gen.go
+/internal/dagger
+/internal/querybuilder
+/internal/telemetry
+/.env

--- a/dagger/dagger.json
+++ b/dagger/dagger.json
@@ -1,0 +1,8 @@
+{
+  "name": "vault-base-setup",
+  "engineVersion": "v0.15.1",
+  "sdk": {
+    "source": "go"
+  },
+  "source": "."
+}

--- a/dagger/dagger.json
+++ b/dagger/dagger.json
@@ -1,8 +1,8 @@
 {
   "name": "vault-base-setup",
-  "engineVersion": "v0.15.1",
+  "engineVersion": "v0.20.3",
   "sdk": {
     "source": "go"
   },
-  "source": "."
+  "disableDefaultFunctionCaching": true
 }

--- a/dagger/go.mod
+++ b/dagger/go.mod
@@ -1,0 +1,3 @@
+module dagger/vault-base-setup
+
+go 1.23

--- a/dagger/go.mod
+++ b/dagger/go.mod
@@ -1,3 +1,53 @@
 module dagger/vault-base-setup
 
-go 1.23
+go 1.25.0
+
+require (
+	dagger.io/dagger v0.19.11
+	github.com/Khan/genqlient v0.8.1
+	github.com/dagger/otel-go v1.43.0
+	github.com/vektah/gqlparser/v2 v2.5.30
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
+)
+
+require (
+	github.com/99designs/gqlgen v0.17.81 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/sosodev/duration v1.3.1 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.17.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.17.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.41.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.41.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.41.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.41.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.41.0 // indirect
+	go.opentelemetry.io/otel/log v0.17.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/sdk/log v0.17.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
+	golang.org/x/net v0.51.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/text v0.34.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
+)
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.16.0
+
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.16.0
+
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.16.0
+
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.16.0

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	defaultTerraformImage = "hashicorp/terraform:1.10"
-	defaultVaultImage     = "hashicorp/vault:1.18"
-	defaultAlpineImage    = "alpine:3.20"
+	defaultTerraformImage = "hashicorp/terraform:1.14"
+	defaultVaultImage     = "hashicorp/vault:1.21"
+	defaultAlpineImage    = "alpine:3.23"
 	devRootToken          = "dagger-root-token"
 	vaultHostname         = "vault"
 	vaultPort             = 8200
@@ -56,7 +56,7 @@ func New(
 // storage and listens on plain HTTP at :8200 with a fixed root token.
 func (m *VaultBaseSetup) VaultDevService(
 	// +optional
-	// +default="hashicorp/vault:1.18"
+	// +default="hashicorp/vault:1.21"
 	image string,
 	// +optional
 	// +default="dagger-root-token"
@@ -86,10 +86,10 @@ func (m *VaultBaseSetup) VaultDevService(
 func (m *VaultBaseSetup) TestTerraformApplyDev(
 	ctx context.Context,
 	// +optional
-	// +default="hashicorp/terraform:1.10"
+	// +default="hashicorp/terraform:1.14"
 	terraformImage string,
 	// +optional
-	// +default="hashicorp/vault:1.18"
+	// +default="hashicorp/vault:1.21"
 	vaultImage string,
 ) (string, error) {
 	if terraformImage == "" {
@@ -127,10 +127,10 @@ func (m *VaultBaseSetup) TestTerraformApplyDev(
 func (m *VaultBaseSetup) TestTerraformApplyTls(
 	ctx context.Context,
 	// +optional
-	// +default="hashicorp/terraform:1.10"
+	// +default="hashicorp/terraform:1.14"
 	terraformImage string,
 	// +optional
-	// +default="hashicorp/vault:1.18"
+	// +default="hashicorp/vault:1.21"
 	vaultImage string,
 ) (string, error) {
 	if terraformImage == "" {

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -74,7 +74,7 @@ func (m *VaultBaseSetup) VaultDevService(
 		WithExposedPort(vaultPort).
 		AsService(dagger.ContainerAsServiceOpts{
 			Args: []string{
-				"server", "-dev",
+				"vault", "server", "-dev",
 				fmt.Sprintf("-dev-listen-address=0.0.0.0:%d", vaultPort),
 				"-dev-root-token-id=" + rootToken,
 			},
@@ -252,7 +252,7 @@ cluster_addr = "https://vault:8201"
 		WithUser("vault").
 		WithExposedPort(vaultPort).
 		AsService(dagger.ContainerAsServiceOpts{
-			Args: []string{"server", "-config=/vault/config/config.hcl"},
+			Args: []string{"vault", "server", "-config=/vault/config/config.hcl"},
 		})
 }
 

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -1,0 +1,308 @@
+// Dagger module for testing vault-base-setup against an ephemeral Vault.
+//
+// Two test entry points are exposed:
+//
+//   - TestTerraformApplyDev runs `terraform apply` against a Vault container
+//     started in dev mode (auto-unsealed, plain HTTP, fixed root token).
+//
+//   - TestTerraformApplyTls runs `terraform apply` against a Vault container
+//     configured with a self-signed TLS cert and file storage, initialised
+//     and unsealed from a helper container, then exercised over HTTPS with
+//     VAULT_CACERT wired up for proper CA verification.
+//
+// The test fixture lives at dagger/tests/fixture.tf and exercises the
+// Vault-native features of the root module (AppRole, UserPass, KV, PKI,
+// policies). Kubernetes / Helm / cert-manager / VSO / CSI features are
+// disabled because no live cluster is available inside the Dagger runtime.
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dagger/vault-base-setup/internal/dagger"
+)
+
+const (
+	defaultTerraformImage = "hashicorp/terraform:1.10"
+	defaultVaultImage     = "hashicorp/vault:1.18"
+	defaultAlpineImage    = "alpine:3.20"
+	devRootToken          = "dagger-root-token"
+	vaultHostname         = "vault"
+	vaultPort             = 8200
+)
+
+type VaultBaseSetup struct {
+	// Source is the root of the terraform module being tested (the repo root,
+	// i.e. the directory containing vault.tf, auth.tf, pki.tf, etc.).
+	// +private
+	Source *dagger.Directory
+}
+
+// New constructs the module. Pass the repository root as `source`, for
+// example: `dagger call -m ./dagger --source=. test-terraform-apply-dev`.
+func New(
+	// Repository root containing the terraform module under test.
+	// +defaultPath=".."
+	// +ignore=[".dagger", "**/.terraform", "**/terraform.tfstate*"]
+	source *dagger.Directory,
+) *VaultBaseSetup {
+	return &VaultBaseSetup{Source: source}
+}
+
+// VaultDevService returns a Vault container running in dev mode as a Dagger
+// service. The server is auto-initialised, auto-unsealed, uses in-memory
+// storage and listens on plain HTTP at :8200 with a fixed root token.
+func (m *VaultBaseSetup) VaultDevService(
+	// +optional
+	// +default="hashicorp/vault:1.18"
+	image string,
+	// +optional
+	// +default="dagger-root-token"
+	rootToken string,
+) *dagger.Service {
+	if image == "" {
+		image = defaultVaultImage
+	}
+	if rootToken == "" {
+		rootToken = devRootToken
+	}
+
+	return dag.Container().
+		From(image).
+		WithExposedPort(vaultPort).
+		AsService(dagger.ContainerAsServiceOpts{
+			Args: []string{
+				"server", "-dev",
+				fmt.Sprintf("-dev-listen-address=0.0.0.0:%d", vaultPort),
+				"-dev-root-token-id=" + rootToken,
+			},
+		})
+}
+
+// TestTerraformApplyDev runs `terraform init` + `terraform apply` against a
+// Vault dev-mode service. Returns the terraform output on success.
+func (m *VaultBaseSetup) TestTerraformApplyDev(
+	ctx context.Context,
+	// +optional
+	// +default="hashicorp/terraform:1.10"
+	terraformImage string,
+	// +optional
+	// +default="hashicorp/vault:1.18"
+	vaultImage string,
+) (string, error) {
+	if terraformImage == "" {
+		terraformImage = defaultTerraformImage
+	}
+	if vaultImage == "" {
+		vaultImage = defaultVaultImage
+	}
+
+	vault := m.VaultDevService(vaultImage, devRootToken)
+	vaultAddr := fmt.Sprintf("http://%s:%d", vaultHostname, vaultPort)
+
+	out, err := m.terraformContainer(terraformImage).
+		WithServiceBinding(vaultHostname, vault).
+		WithEnvVariable("VAULT_TOKEN", devRootToken).
+		WithEnvVariable("VAULT_ADDR", vaultAddr).
+		WithExec([]string{"terraform", "init", "-input=false", "-no-color"}).
+		WithExec([]string{
+			"terraform", "apply", "-auto-approve", "-input=false", "-no-color",
+			"-var=vault_addr=" + vaultAddr,
+			"-var=skip_tls_verify=true",
+		}).
+		WithExec([]string{"terraform", "output", "-no-color"}).
+		Stdout(ctx)
+	if err != nil {
+		return "", fmt.Errorf("terraform apply (dev) failed: %w", err)
+	}
+	return fmt.Sprintf("test terraform-apply-dev: OK\n%s", out), nil
+}
+
+// TestTerraformApplyTls runs `terraform init` + `terraform apply` against a
+// Vault server that listens over HTTPS with a self-signed cert and has been
+// initialised + unsealed by a helper container. The terraform client verifies
+// the Vault CA via VAULT_CACERT.
+func (m *VaultBaseSetup) TestTerraformApplyTls(
+	ctx context.Context,
+	// +optional
+	// +default="hashicorp/terraform:1.10"
+	terraformImage string,
+	// +optional
+	// +default="hashicorp/vault:1.18"
+	vaultImage string,
+) (string, error) {
+	if terraformImage == "" {
+		terraformImage = defaultTerraformImage
+	}
+	if vaultImage == "" {
+		vaultImage = defaultVaultImage
+	}
+
+	certs := m.generateTlsCerts(vaultHostname)
+	vault := m.vaultTlsService(vaultImage, certs)
+	vaultAddr := fmt.Sprintf("https://%s:%d", vaultHostname, vaultPort)
+
+	rootToken, err := m.initAndUnsealVault(ctx, vaultImage, vault, certs, vaultAddr)
+	if err != nil {
+		return "", err
+	}
+
+	out, err := m.terraformContainer(terraformImage).
+		WithServiceBinding(vaultHostname, vault).
+		WithMountedDirectory("/vault-ca", certs).
+		WithEnvVariable("VAULT_TOKEN", rootToken).
+		WithEnvVariable("VAULT_ADDR", vaultAddr).
+		WithEnvVariable("VAULT_CACERT", "/vault-ca/ca.pem").
+		WithExec([]string{"terraform", "init", "-input=false", "-no-color"}).
+		WithExec([]string{
+			"terraform", "apply", "-auto-approve", "-input=false", "-no-color",
+			"-var=vault_addr=" + vaultAddr,
+			"-var=skip_tls_verify=false",
+		}).
+		WithExec([]string{"terraform", "output", "-no-color"}).
+		Stdout(ctx)
+	if err != nil {
+		return "", fmt.Errorf("terraform apply (tls) failed: %w", err)
+	}
+	return fmt.Sprintf("test terraform-apply-tls: OK\n%s", out), nil
+}
+
+// terraformContainer mounts the repo at /src and chdirs into the test
+// fixture. The fixture references the parent module via `source = "../../"`.
+func (m *VaultBaseSetup) terraformContainer(image string) *dagger.Container {
+	return dag.Container().
+		From(image).
+		WithMountedDirectory("/src", m.Source).
+		WithWorkdir("/src/dagger/tests")
+}
+
+// generateTlsCerts produces a self-signed CA and server cert/key via openssl.
+// Returned directory contains: ca.pem, ca.key, server.pem, server.key.
+func (m *VaultBaseSetup) generateTlsCerts(hostname string) *dagger.Directory {
+	script := fmt.Sprintf(`set -eu
+cd /out
+openssl genrsa -out ca.key 2048
+openssl req -new -x509 -days 3650 -key ca.key -out ca.pem \
+  -subj "/CN=dagger-vault-ca"
+openssl genrsa -out server.key 2048
+cat > csr.conf <<EOF
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+req_extensions = req_ext
+[dn]
+CN = %s
+[req_ext]
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = %s
+DNS.2 = localhost
+IP.1 = 127.0.0.1
+EOF
+openssl req -new -key server.key -out server.csr -config csr.conf
+openssl x509 -req -in server.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
+  -out server.pem -days 365 -extfile csr.conf -extensions req_ext
+rm -f server.csr csr.conf ca.srl
+`, hostname, hostname)
+
+	return dag.Container().
+		From(defaultAlpineImage).
+		WithExec([]string{"apk", "add", "--no-cache", "openssl"}).
+		WithWorkdir("/out").
+		WithExec([]string{"sh", "-c", script}).
+		Directory("/out")
+}
+
+// vaultTlsService returns a Vault container running in server mode with TLS
+// and file storage, listening on :8200. The returned service is sealed on
+// startup and must be initialised + unsealed before use.
+func (m *VaultBaseSetup) vaultTlsService(image string, certs *dagger.Directory) *dagger.Service {
+	config := `
+ui            = true
+disable_mlock = true
+
+storage "file" {
+  path = "/vault/data"
+}
+
+listener "tcp" {
+  address       = "0.0.0.0:8200"
+  tls_cert_file = "/vault/tls/server.pem"
+  tls_key_file  = "/vault/tls/server.key"
+}
+
+api_addr     = "https://vault:8200"
+cluster_addr = "https://vault:8201"
+`
+
+	// The hashicorp/vault image runs as the unprivileged `vault` user, so we
+	// copy the TLS material in as root, create the storage dir, then chown
+	// everything before the service starts.
+	return dag.Container().
+		From(image).
+		WithUser("root").
+		WithDirectory("/vault/tls", certs).
+		WithNewFile("/vault/config/config.hcl", config).
+		WithExec([]string{"sh", "-c",
+			"mkdir -p /vault/data && chown -R vault:vault /vault/data /vault/tls /vault/config"}).
+		WithUser("vault").
+		WithExposedPort(vaultPort).
+		AsService(dagger.ContainerAsServiceOpts{
+			Args: []string{"server", "-config=/vault/config/config.hcl"},
+		})
+}
+
+// initAndUnsealVault runs `vault operator init` + `vault operator unseal`
+// against the TLS-enabled service and returns the root token on stdout.
+func (m *VaultBaseSetup) initAndUnsealVault(
+	ctx context.Context,
+	image string,
+	vault *dagger.Service,
+	certs *dagger.Directory,
+	vaultAddr string,
+) (string, error) {
+	// Wait for Vault API to respond: exit 0 = unsealed, 2 = sealed, 1 = error.
+	// Then init with a single unseal key, unseal, and print only the root token.
+	script := `set -eu
+ready=0
+for i in $(seq 1 60); do
+  set +e
+  vault status >/dev/null 2>&1
+  code=$?
+  set -e
+  case $code in
+    0|2) ready=1; break ;;
+  esac
+  sleep 1
+done
+[ "$ready" -eq 1 ] || { echo "vault did not become reachable" >&2; exit 1; }
+vault operator init -key-shares=1 -key-threshold=1 -format=json > /tmp/init.json
+UNSEAL_KEY=$(jq -r '.unseal_keys_b64[0]' /tmp/init.json)
+vault operator unseal "$UNSEAL_KEY" >/dev/null
+jq -r '.root_token' /tmp/init.json
+`
+
+	rawToken, err := dag.Container().
+		From(image).
+		WithUser("root").
+		WithExec([]string{"apk", "add", "--no-cache", "jq"}).
+		WithServiceBinding(vaultHostname, vault).
+		WithMountedDirectory("/vault-ca", certs).
+		WithEnvVariable("VAULT_ADDR", vaultAddr).
+		WithEnvVariable("VAULT_CACERT", "/vault-ca/ca.pem").
+		WithExec([]string{"sh", "-c", script}).
+		Stdout(ctx)
+	if err != nil {
+		return "", fmt.Errorf("vault init/unseal failed: %w", err)
+	}
+
+	token := strings.TrimSpace(rawToken)
+	if token == "" {
+		return "", fmt.Errorf("vault init returned empty root token")
+	}
+	return token, nil
+}

--- a/dagger/tests/fixture.tf
+++ b/dagger/tests/fixture.tf
@@ -1,0 +1,121 @@
+terraform {
+  required_version = ">= 1.10.0"
+}
+
+variable "vault_addr" {
+  type = string
+}
+
+variable "skip_tls_verify" {
+  type    = bool
+  default = false
+}
+
+# Bogus kubeconfig needed to satisfy the module's kubeconfig validation
+# (k8s.tf). No K8s-backed resources are created in this test, so the
+# providers configured from it are never actually called.
+variable "dummy_kubeconfig" {
+  type    = string
+  default = <<-EOT
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: dagger
+        cluster:
+          server: https://127.0.0.1:6443
+          certificate-authority-data: ""
+    users:
+      - name: dagger
+        user:
+          client-certificate-data: ""
+          client-key-data: ""
+    contexts:
+      - name: dagger
+        context:
+          cluster: dagger
+          user: dagger
+    current-context: dagger
+  EOT
+}
+
+module "vault_base_setup" {
+  source = "../../"
+
+  vault_addr         = var.vault_addr
+  skip_tls_verify    = var.skip_tls_verify
+  kubeconfig_content = var.dummy_kubeconfig
+  cluster_name       = "dagger-test"
+
+  # Keep Kubernetes / Helm driven features off - we test Vault-API features only.
+  vault_enabled                    = false
+  csi_enabled                      = false
+  vso_enabled                      = false
+  certmanager_enabled              = false
+  certmanager_bootstrap_enabled    = false
+  certmanager_vault_issuer_enabled = false
+
+  enableApproleAuth        = true
+  enableUserPass           = true
+  createDefaultAdminPolicy = true
+
+  approle_roles = [
+    { name = "app", token_policies = ["read-app-kv"] },
+  ]
+
+  user_list = [
+    {
+      path      = "auth/userpass/users/tester"
+      data_json = jsonencode({ password = "dagger-test", policies = "read-app-kv" })
+    },
+  ]
+
+  secret_engines = [
+    {
+      path        = "apps"
+      name        = "app"
+      description = "dagger test secrets"
+      data_json = jsonencode({
+        username = "foo"
+        password = "bar" # pragma: allowlist secret
+      })
+    },
+  ]
+
+  kv_policies = [
+    {
+      name         = "read-app-kv"
+      capabilities = <<-EOT
+        path "apps/data/app" {
+          capabilities = ["read"]
+        }
+      EOT
+    },
+  ]
+
+  pki_enabled      = true
+  pki_path         = "pki"
+  pki_common_name  = "dagger.example.com"
+  pki_organization = "stuttgart-things"
+  pki_country      = "DE"
+
+  pki_roles = [
+    {
+      name             = "dagger-role"
+      allowed_domains  = ["dagger.example.com"]
+      allow_subdomains = true
+      max_ttl          = "72h"
+    },
+  ]
+}
+
+output "role_ids" {
+  value = module.vault_base_setup.role_id
+}
+
+output "pki_path" {
+  value = module.vault_base_setup.pki_path
+}
+
+output "pki_roles" {
+  value = module.vault_base_setup.pki_roles
+}


### PR DESCRIPTION
## Summary

Adds a Dagger Go module (`dagger/`) that runs `terraform apply` against an ephemeral Vault container, enabling local + CI testing of the module without a live Kubernetes cluster.

Two entry points:

- **`test-terraform-apply-dev`** — Vault in dev mode (HTTP, auto-unsealed, fixed root token). Fast smoke test.
- **`test-terraform-apply-tls`** — Vault in server mode with a self-signed TLS cert + file storage. A helper container runs `vault operator init` + `vault operator unseal`, then terraform applies against HTTPS with `VAULT_CACERT` wired up for proper CA verification.

Both exercise the Vault-API features of the root module: AppRole, UserPass, KV v2, PKI, policies. K8s / Helm / cert-manager / VSO / CSI are disabled in the fixture because no live cluster exists in the Dagger runtime; a bogus kubeconfig satisfies the module's kubeconfig validation.

## Files

- `dagger/main.go` — Dagger module: `VaultDevService`, `vaultTlsService`, `generateTlsCerts` (openssl), `initAndUnsealVault`, plus the two test entry points
- `dagger/tests/fixture.tf` — Terraform fixture referencing the parent module via `source = "../../"`
- `dagger/dagger.json`, `dagger/go.mod` — Dagger module config
- `Taskfile.yaml` — `dagger:test-dev`, `dagger:test-tls`, `dagger:test` targets
- `README.md` — DAGGER TESTS section (cherry-pick of `2c25663` from `claude/...` pending)

## Default images

- `hashicorp/terraform:1.14`
- `hashicorp/vault:1.21`
- `alpine:3.23`

## Test plan

- [x] `dagger -m ./dagger call test-terraform-apply-dev` — passes (PKI mounted, AppRole role_id returned)
- [x] `dagger -m ./dagger call test-terraform-apply-tls` — passes (init + unseal + TLS apply)
- [ ] CI green