### PR TITLE
feat: add kubernetes auth for the cert-manager ClusterIssuer

### DIFF
--- a/cert-manager.tf
+++ b/cert-manager.tf
@@ -19,6 +19,13 @@ resource "null_resource" "validate_certmanager_vault_issuer" {
       condition     = var.certmanager_vault_issuer_pki_role != ""
       error_message = "certmanager_vault_issuer_pki_role must be set when certmanager_vault_issuer_enabled is true."
     }
+    precondition {
+      condition = (
+        var.certmanager_vault_issuer_auth_method != "kubernetes"
+        || (var.certmanager_vault_issuer_k8s_auth_mount != "" && var.certmanager_vault_issuer_k8s_auth_role != "")
+      )
+      error_message = "certmanager_vault_issuer_k8s_auth_mount and certmanager_vault_issuer_k8s_auth_role must be set when certmanager_vault_issuer_auth_method is \"kubernetes\"."
+    }
   }
 }
 
@@ -144,9 +151,31 @@ locals {
   )
 }
 
+locals {
+  // STATIC TOKEN AUTH IS THE DEFAULT, BUT IT EXPIRES.
+  // The token is created once by Terraform and nothing renews it: the provider
+  // only renews during an apply, and there is no in-cluster renewer. Vault also
+  // caps token TTLs at the token mount's max_lease_ttl (768h by default), so a
+  // longer TTL is not a way out. Prefer auth_method = "kubernetes".
+  certmanager_vault_issuer_uses_token = (
+    var.certmanager_vault_issuer_enabled && var.certmanager_vault_issuer_auth_method == "token"
+  )
+
+  certmanager_vault_issuer_uses_k8s = (
+    var.certmanager_vault_issuer_enabled && var.certmanager_vault_issuer_auth_method == "kubernetes"
+  )
+
+  // SERVICE ACCOUNT CERT-MANAGER PRESENTS WHEN LOGGING IN TO VAULT
+  certmanager_vault_issuer_effective_sa = (
+    var.certmanager_vault_issuer_service_account != ""
+    ? var.certmanager_vault_issuer_service_account
+    : var.certmanager_vault_issuer_k8s_auth_role
+  )
+}
+
 // VAULT TOKEN FOR CERT-MANAGER
 resource "vault_token" "certmanager" {
-  count = var.certmanager_vault_issuer_enabled ? 1 : 0
+  count = local.certmanager_vault_issuer_uses_token ? 1 : 0
   policies = [
     var.certmanager_vault_issuer_policy_name != ""
     ? var.certmanager_vault_issuer_policy_name
@@ -172,7 +201,7 @@ moved {
 
 // KUBERNETES SECRET FOR VAULT TOKEN
 resource "kubernetes_secret_v1" "certmanager_vault_token" {
-  count = var.certmanager_vault_issuer_enabled ? 1 : 0
+  count = local.certmanager_vault_issuer_uses_token ? 1 : 0
 
   metadata {
     name      = var.certmanager_vault_token_secret_name
@@ -221,12 +250,23 @@ resource "kubectl_manifest" "vault_clusterissuer" {
         {
           path   = "${var.pki_path}/sign/${var.certmanager_vault_issuer_pki_role}"
           server = local.certmanager_vault_issuer_effective_server
-          auth = {
-            tokenSecretRef = {
-              name = var.certmanager_vault_token_secret_name
-              key  = "token"
+          auth = merge(
+            local.certmanager_vault_issuer_uses_k8s ? {
+              kubernetes = {
+                mountPath = "/v1/auth/${var.certmanager_vault_issuer_k8s_auth_mount}"
+                role      = var.certmanager_vault_issuer_k8s_auth_role
+                serviceAccountRef = {
+                  name = local.certmanager_vault_issuer_effective_sa
+                }
+              }
+            } : {},
+            local.certmanager_vault_issuer_uses_k8s ? {} : {
+              tokenSecretRef = {
+                name = var.certmanager_vault_token_secret_name
+                key  = "token"
+              }
             }
-          }
+          )
         },
         local.certmanager_vault_issuer_effective_ca_bundle != null ? {
           caBundleSecretRef = {
@@ -243,4 +283,47 @@ resource "kubectl_manifest" "vault_clusterissuer" {
     kubernetes_secret_v1.vault_ca_bundle,
     null_resource.validate_certmanager_vault_issuer,
   ]
+}
+
+// ALLOW THE CERT-MANAGER CONTROLLER TO MINT TOKENS FOR THE LOGIN SERVICE ACCOUNT.
+// With serviceAccountRef, cert-manager requests a short-lived token via the
+// TokenRequest API. The chart ships a "cert-manager-tokenrequest" Role, but it is
+// scoped via resourceNames to the "cert-manager" ServiceAccount only — any other
+// ServiceAccount needs its own grant, which is easy to miss and fails at issuance
+// time rather than at apply time.
+resource "kubernetes_role_v1" "certmanager_tokenrequest" {
+  count = local.certmanager_vault_issuer_uses_k8s && var.certmanager_vault_issuer_create_tokenrequest_role ? 1 : 0
+
+  metadata {
+    name      = "${local.certmanager_vault_issuer_effective_sa}-tokenrequest"
+    namespace = var.certmanager_vault_issuer_namespace
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["serviceaccounts/token"]
+    resource_names = [local.certmanager_vault_issuer_effective_sa]
+    verbs          = ["create"]
+  }
+}
+
+resource "kubernetes_role_binding_v1" "certmanager_tokenrequest" {
+  count = local.certmanager_vault_issuer_uses_k8s && var.certmanager_vault_issuer_create_tokenrequest_role ? 1 : 0
+
+  metadata {
+    name      = "${local.certmanager_vault_issuer_effective_sa}-tokenrequest"
+    namespace = var.certmanager_vault_issuer_namespace
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role_v1.certmanager_tokenrequest[0].metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = var.certmanager_vault_issuer_controller_service_account
+    namespace = var.certmanager_namespace
+  }
 }

--- a/docs/pki-ca.md
+++ b/docs/pki-ca.md
@@ -107,6 +107,21 @@ curl -sk \
 
 ## Step 3: Create a Vault Token for cert-manager
 
+> **This token expires and nothing renews it.** Terraform creates it once; the provider
+> only renews during an apply, and there is no in-cluster renewer. Roughly
+> `certmanager_vault_token_ttl` after each apply, every certificate issuance starts
+> failing with `permission denied / invalid token` — while the ClusterIssuer keeps
+> reporting `Ready=True`, because cert-manager only health-checks a Vault issuer at
+> setup. If the certificate lifetime exceeds the token TTL, the first renewal is
+> guaranteed to hit a dead token.
+>
+> Raising the TTL does not fix it: Vault caps token TTLs at the token mount's
+> `max_lease_ttl`, which defaults to `768h` (32 days), and silently truncates larger
+> values instead of rejecting them.
+>
+> Prefer `certmanager_vault_issuer_auth_method = "kubernetes"` — see
+> [Kubernetes auth](#kubernetes-auth-recommended) below. There is nothing to expire.
+
 Create a token scoped to the `pki-issue` policy:
 
 ```bash
@@ -337,3 +352,80 @@ Common causes:
 - The Vault token has expired - create a new one and update the secret
 - The PKI role does not allow the requested domain - check `allowed_domains` and `allow_subdomains`
 - The requested TTL exceeds the role's `max_ttl`
+
+## Kubernetes auth (recommended)
+
+Instead of a static token, let cert-manager authenticate to Vault with a short-lived
+ServiceAccount token minted per request via the TokenRequest API. Nothing expires, so the
+failure mode described in Step 3 cannot occur.
+
+```hcl
+module "vault-base-setup" {
+  source = "github.com/stuttgart-things/vault-base-setup?ref=<tag>"
+
+  # ... vault_addr, kubeconfig_path, cluster_name, pki settings ...
+
+  # CREATE THE AUTH MOUNT. Path becomes "<cluster_name>-<name>".
+  k8s_auths = [
+    {
+      name           = "certmanager-vault"
+      namespace      = "cert-manager"
+      token_policies = ["pki-issue"]
+      token_ttl      = 3600
+    }
+  ]
+
+  certmanager_vault_issuer_enabled        = true
+  certmanager_vault_issuer_pki_role       = "sthings-vsphere"
+  certmanager_vault_issuer_auth_method    = "kubernetes"
+  certmanager_vault_issuer_k8s_auth_mount = "<cluster_name>-certmanager-vault"
+  certmanager_vault_issuer_k8s_auth_role  = "certmanager-vault"
+}
+```
+
+Notes:
+
+- **Vault must reach the target cluster's API server.** The auth mount is configured with
+  the API server address from the kubeconfig. For a cross-cluster setup — Vault on one
+  cluster, cert-manager on another — verify this first, e.g. from the Vault pod:
+  `curl -sk https://<api-server>:6443/version` (an HTTP 401 means reachable, which is
+  what you want).
+- **The login ServiceAccount needs a TokenRequest grant.** cert-manager ships a
+  `cert-manager-tokenrequest` Role scoped via `resourceNames` to its own `cert-manager`
+  ServiceAccount, so any other ServiceAccount needs its own. The module creates it by
+  default (`certmanager_vault_issuer_create_tokenrequest_role`). Without it, issuance
+  fails at runtime rather than at apply time.
+- **To admit an existing ServiceAccount** instead of the one the module creates — for
+  example cert-manager's own, which is Helm-managed — set
+  `bound_service_account_names` / `bound_service_account_namespaces` on the `k8s_auths`
+  entry. The module's ServiceAccount remains the token reviewer either way.
+- **`caBundle` is still required** when the issuer reaches Vault over HTTPS with a
+  privately signed certificate; the auth method does not change that.
+
+### Migrating an existing token-based issuer
+
+Deploy the Kubernetes-auth issuer under a **different name** first, verify it with a test
+certificate, and only then repoint your `Certificate` resources. That keeps the working
+issuer as a fallback:
+
+```bash
+kubectl get certificate <name> -n <ns> \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+```
+
+If certificates had already been failing, cert-manager will be in exponential backoff and
+will not retry just because the issuer was fixed. Reset the counters to force an immediate
+attempt:
+
+```bash
+kubectl patch certificate <name> -n <ns> --subresource=status --type=merge \
+  -p '{"status":{"failedIssuanceAttempts":null,"lastFailureTime":null}}'
+```
+
+Confirm which issuer actually signed the result — a `Ready=True` alone can be a stale
+status from before the switch:
+
+```bash
+kubectl get secret <secret> -n <ns> \
+  -o jsonpath='{.metadata.annotations.cert-manager\.io/issuer-name}'
+```

--- a/k8s.tf
+++ b/k8s.tf
@@ -122,12 +122,23 @@ resource "vault_kubernetes_auth_backend_role" "backend_role" {
     auth.name => auth
   }
 
-  backend                          = "${var.cluster_name}-${each.value["name"]}"
-  role_name                        = each.value["name"]
-  bound_service_account_names      = [each.value["name"]]
-  bound_service_account_namespaces = [each.value["namespace"]]
-  token_ttl                        = each.value["token_ttl"]
-  token_policies                   = each.value["token_policies"]
+  backend   = "${var.cluster_name}-${each.value["name"]}"
+  role_name = each.value["name"]
+
+  // DEFAULTS TO THE SERVICEACCOUNT THIS MODULE CREATES, BUT CAN ADMIT AN EXISTING ONE
+  bound_service_account_names = (
+    each.value["bound_service_account_names"] != null
+    ? each.value["bound_service_account_names"]
+    : [each.value["name"]]
+  )
+  bound_service_account_namespaces = (
+    each.value["bound_service_account_namespaces"] != null
+    ? each.value["bound_service_account_namespaces"]
+    : [each.value["namespace"]]
+  )
+
+  token_ttl      = each.value["token_ttl"]
+  token_policies = each.value["token_policies"]
 
   depends_on = [
     vault_kubernetes_auth_backend_config.kubernetes

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,14 @@ variable "k8s_auths" {
     namespace      = string
     token_policies = list(string)
     token_ttl      = number
+
+    # Which ServiceAccounts may log in through this mount. Defaults to the
+    # ServiceAccount this module creates ([name] / [namespace]). Override to
+    # admit an existing ServiceAccount instead — e.g. cert-manager's, which is
+    # Helm-managed and cannot be recreated here. The module's own SA stays the
+    # token reviewer either way.
+    bound_service_account_names      = optional(list(string))
+    bound_service_account_namespaces = optional(list(string))
   }))
   default     = []
   description = "A list of k8s_auth objects"
@@ -544,10 +552,85 @@ variable "certmanager_vault_issuer_pki_role" {
   default     = ""
 }
 
+variable "certmanager_vault_issuer_auth_method" {
+  description = <<-EOT
+    How the ClusterIssuer authenticates to Vault.
+
+    "token" (default) creates a static vault_token and stores it in a Secret.
+    Nothing renews that token — the Terraform provider only renews during an
+    apply — so Vault auth breaks roughly certmanager_vault_token_ttl after every
+    apply, while the ClusterIssuer keeps reporting Ready=True.
+
+    "kubernetes" uses Vault Kubernetes auth: cert-manager mints a short-lived
+    ServiceAccount token per request, so there is nothing to expire. Prefer it.
+    Requires certmanager_vault_issuer_k8s_auth_mount and _k8s_auth_role.
+  EOT
+  type        = string
+  default     = "token"
+
+  validation {
+    condition     = contains(["token", "kubernetes"], var.certmanager_vault_issuer_auth_method)
+    error_message = "certmanager_vault_issuer_auth_method must be either \"token\" or \"kubernetes\"."
+  }
+}
+
+variable "certmanager_vault_issuer_k8s_auth_mount" {
+  description = "Vault Kubernetes auth mount path (without the /v1/auth/ prefix), e.g. \"my-cluster-certmanager\". Required when auth method is \"kubernetes\"."
+  type        = string
+  default     = ""
+}
+
+variable "certmanager_vault_issuer_k8s_auth_role" {
+  description = "Vault Kubernetes auth role name. Required when auth method is \"kubernetes\"."
+  type        = string
+  default     = ""
+}
+
+variable "certmanager_vault_issuer_service_account" {
+  description = "ServiceAccount cert-manager presents when logging in to Vault. Defaults to certmanager_vault_issuer_k8s_auth_role. Must be listed in the Vault role's bound_service_account_names."
+  type        = string
+  default     = ""
+}
+
+variable "certmanager_vault_issuer_create_tokenrequest_role" {
+  description = <<-EOT
+    Create the Role/RoleBinding letting the cert-manager controller mint tokens
+    for the login ServiceAccount. cert-manager ships a tokenrequest Role scoped
+    via resourceNames to its own "cert-manager" ServiceAccount only, so any other
+    ServiceAccount needs this grant — without it issuance fails at runtime, not
+    at apply time. Only used when auth method is "kubernetes".
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "certmanager_vault_issuer_controller_service_account" {
+  description = "Name of the cert-manager controller ServiceAccount that is granted TokenRequest access to the login ServiceAccount."
+  type        = string
+  default     = "cert-manager"
+}
+
 variable "certmanager_vault_token_ttl" {
-  description = "TTL for the Vault token used by cert-manager"
+  description = <<-EOT
+    TTL for the Vault token used by cert-manager. Only used when
+    certmanager_vault_issuer_auth_method is "token".
+
+    Vault caps this at the token mount's max_lease_ttl, which defaults to 768h
+    (32 days) — larger values are silently truncated rather than rejected, so
+    raising this is not a way to avoid the expiry. Use auth_method "kubernetes"
+    instead.
+  EOT
   type        = string
   default     = "720h"
+
+  validation {
+    condition = (
+      can(regex("^[0-9]+h$", var.certmanager_vault_token_ttl))
+      ? tonumber(trimsuffix(var.certmanager_vault_token_ttl, "h")) <= 768
+      : true
+    )
+    error_message = "certmanager_vault_token_ttl exceeds Vault's default token mount max_lease_ttl of 768h; a larger value would be silently truncated. Raise sys/auth/token/tune first, or use certmanager_vault_issuer_auth_method = \"kubernetes\"."
+  }
 }
 
 variable "certmanager_vault_token_secret_name" {


### PR DESCRIPTION
Fixes #46 (P1 items 1–3). Backwards compatible — existing callers are unaffected.

## Problem

The ClusterIssuer could only authenticate to Vault one way: a static `vault_token` stored in a Secret and referenced via `tokenSecretRef`.

```hcl
resource "vault_token" "certmanager" {
  ttl       = var.certmanager_vault_token_ttl   # default "720h"
  renewable = true
}
```

`renewable = true` reads like self-healing but is inert — the Terraform Vault provider only renews during an `apply`, and `renew_min_lease` is not set. There is no in-cluster renewer, so **Vault auth breaks roughly 30 days after every apply**.

Three things make it worse:

1. **It is silent.** cert-manager only health-checks a Vault issuer at setup, so the ClusterIssuer reports `Ready=True` throughout while every issuance fails with `permission denied / invalid token`.
2. **It is guaranteed, not incidental.** The default token TTL (720h / 30d) is shorter than a typical certificate lifetime (2160h / 90d), so the *first* renewal always hits a dead token.
3. **The obvious workaround does not work.** Vault caps token TTLs at the token mount's `max_lease_ttl` — `768h` by default — and **silently truncates** larger values rather than rejecting them. Setting `87600h` looks like it worked and fails a month later.

Real impact: HTTPS on `infra-sthings` was down for 17 days before anyone noticed, and a wildcard certificate on `platform-sthings` had already expired.

## Change

### 1. `certmanager_vault_issuer_auth_method = "token" | "kubernetes"`

Defaults to `"token"`, so nothing changes for existing callers. With `"kubernetes"` the issuer emits `spec.vault.auth.kubernetes` and cert-manager mints a short-lived ServiceAccount token per request via the TokenRequest API — nothing left to expire. The `vault_token` and its Secret are not created at all in that mode.

```hcl
certmanager_vault_issuer_auth_method    = "kubernetes"
certmanager_vault_issuer_k8s_auth_mount = "my-cluster-certmanager-vault"
certmanager_vault_issuer_k8s_auth_role  = "certmanager-vault"
```

### 2. TokenRequest Role for the login ServiceAccount

cert-manager ships a `cert-manager-tokenrequest` Role, but it is scoped via `resourceNames` to its own `cert-manager` ServiceAccount. Any other ServiceAccount referenced by `serviceAccountRef` needs its own grant — and the absence only surfaces **at issuance time, not at apply time**, so it is easy to miss. Created by default; opt out with `certmanager_vault_issuer_create_tokenrequest_role = false`.

### 3. `bound_service_account_names` / `_namespaces` optional on `k8s_auths`

They were hardcoded to the ServiceAccount the module creates:

```hcl
bound_service_account_names      = [each.value["name"]]
bound_service_account_namespaces = [each.value["namespace"]]
```

so the auth role could only ever admit the module's own ServiceAccount, and an **existing** one — e.g. cert-manager's, which is Helm-managed and cannot be recreated here — could never be used. Now optional, defaulting to the previous behaviour. The module's ServiceAccount remains the token reviewer either way.

### 4. Validation on `certmanager_vault_token_ttl`

Rejects values above Vault's default 768h cap with an error message pointing at `sys/auth/token/tune`, instead of letting Vault truncate silently.

## Verification

Both auth methods render the expected manifest:

```yaml
# auth_method = "token"          # auth_method = "kubernetes"
auth:                            auth:
  tokenSecretRef:                  kubernetes:
    key: token                       mountPath: /v1/auth/my-cluster-certmanager
    name: vault-pki-token            role: certmanager-vault
                                     serviceAccountRef:
                                       name: certmanager-vault
```

TTL validation boundaries:

```
720h   -> accepted
768h   -> accepted
769h   -> rejected
87600h -> rejected
```

`terraform validate` passes. The `"kubernetes"` path is not merely theoretical — it is running in production on both `infra-sthings` (in-cluster Vault) and `platform-sthings` (cross-cluster, Vault on another cluster), hand-wired in exactly this shape before being upstreamed here.

## Docs

`docs/pki-ca.md` gains a warning on the token step explaining the expiry and why raising the TTL does not help, plus a "Kubernetes auth (recommended)" section covering cross-cluster reachability, the TokenRequest grant, admitting an existing ServiceAccount, and a migration recipe — including the non-obvious part: after repeated failures cert-manager sits in exponential backoff and will **not** retry just because the issuer was fixed, so the counters have to be reset.

## Not included

The remaining findings from #46 — one-secret-per-KV-mount, the `max_ttl` perpetual diff, provider blocks inside the module, `kubernetes_manifest` requiring a cluster at plan time — are left for separate PRs. The provider-block change in particular breaks every caller and wants its own major bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSLXgANJSrsxSevzyH96EZ
