### PR TITLE
feat: allow multiple secrets per KV mount, drop kubernetes_manifest for the SA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ terraform.rc
 # Dagger generated artifacts
 dagger/.dagger/
 dagger/go.sum
+
+# Provider lock file — a shared module must not pin provider versions for callers
+.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # stuttgart-things/vault-base-setup
 
+> **Upgrading to v1.2.0?** KV secrets and the `k8s_auths` ServiceAccount moved to new state
+> addresses. `terraform state` surgery is required before the first apply — without it
+> Terraform deletes secret data and recreates the ServiceAccount. See
+> [docs/migration.md](docs/migration.md).
+
 terraform module for base-setup configuration of hashicorp vault.
 
 ## EXAMPLE USAGE
@@ -183,6 +188,18 @@ module "vault-secrets-setup" {
       description = "kubeconfig for kind-dev2 cluster"
       data_json   = jsonencode({
         kubeconfig = file("/home/sthings/.kube/kind-dev2")
+      })
+    },
+    # SEVERAL ENTRIES MAY SHARE A PATH — one mount, many secrets.
+    # (Before v1.2.0 this was a hard "Duplicate object key" error, which forced
+    # one mount per secret.) The mount description comes from the first entry
+    # listed for that path.
+    {
+      path        = "kubeconfigs"
+      name        = "kind-dev3"
+      description = "ignored — 'kind-dev2' above already defines this mount"
+      data_json   = jsonencode({
+        kubeconfig = file("/home/sthings/.kube/kind-dev3")
       })
     }
   ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,11 +2,18 @@
 
 Terraform module for base-setup configuration of HashiCorp Vault.
 
+!!! warning "Upgrading to v1.2.0"
+
+    KV secrets and the `k8s_auths` ServiceAccount moved to new state addresses.
+    `terraform state` surgery is required before the first apply — without it Terraform
+    deletes secret data and recreates the ServiceAccount. See
+    [Migration notes](migration.md).
+
 ## Features
 
 | Feature | Variable | Description |
 |---------|----------|-------------|
-| KV Secrets Engines | `secret_engines` | Mount KV v2 secrets engines and write initial secrets |
+| KV Secrets Engines | `secret_engines` | Mount KV v2 secrets engines and write initial secrets. Entries may share a `path` — one mount, many secrets |
 | KV Policies | `kv_policies` | Create ACL policies for KV access |
 | Kubernetes Auth | `k8s_auths` | Configure Kubernetes auth backends for service account authentication |
 | AppRole Auth | `enableApproleAuth`, `approle_roles` | Enable AppRole auth with configurable roles |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,123 @@
+# Migration notes
+
+## v1.2.0 — KV secret keys and the ServiceAccount resource
+
+Two changes move resources to different state addresses. **Both require `terraform state`
+surgery before the first apply.** Neither is optional: applying without it destroys live
+resources.
+
+Run all commands with the same backend configuration you normally use, and take a state
+backup first:
+
+```bash
+terraform state pull > terraform.tfstate.backup.json
+```
+
+If the module is called as `module.vault-base-setup`, prefix every address accordingly —
+`module.vault-base-setup.vault_generic_secret.kvv2["apps"]`. Adjust the prefix to your
+module name; `terraform state list` shows the exact addresses.
+
+---
+
+### 1. `vault_generic_secret.kvv2` is now keyed by `<path>/<name>`
+
+Previously both the mount and the secret were keyed on `path`, which made two secrets in
+one mount a hard `Duplicate object key` error and forced one mount per secret. Secrets are
+now keyed on `<path>/<name>`.
+
+`vault_mount.kvv2` keys are **unchanged** (still the path). Only the secret addresses move.
+
+**Why you cannot skip this:** the old and new instances resolve to the *same Vault path*.
+Terraform sees one instance removed and another added, and there is no ordering guarantee
+between them. If the destroy runs after the create, **Terraform deletes the secret data it
+just wrote.**
+
+For every entry in `secret_engines`:
+
+```bash
+terraform state mv \
+  'vault_generic_secret.kvv2["<path>"]' \
+  'vault_generic_secret.kvv2["<path>/<name>"]'
+```
+
+Concretely, for `{ name = "creds", path = "apps", ... }`:
+
+```bash
+terraform state mv \
+  'vault_generic_secret.kvv2["apps"]' \
+  'vault_generic_secret.kvv2["apps/creds"]'
+```
+
+Then confirm the plan is clean before applying:
+
+```bash
+terraform plan
+# expect: No changes. Your infrastructure matches the configuration.
+```
+
+**If `terraform plan` shows any `vault_generic_secret` being destroyed, stop.** An address
+was missed. Re-check `terraform state list` against your `secret_engines` entries.
+
+#### Optional: collapse redundant mounts
+
+The one-mount-per-secret workaround is no longer necessary, so entries can now share a
+path. Doing so is a *separate* change — it destroys the now-unused mounts **and every
+secret in them**. Move the secrets to the surviving mount first, or write them fresh.
+Nothing forces you to consolidate; existing layouts keep working untouched.
+
+When several entries share a path, the mount `description` comes from the first entry
+listed for that path.
+
+---
+
+### 2. `kubernetes_manifest.service_account` → `kubernetes_service_account_v1.vault`
+
+The ServiceAccount created for `k8s_auths` no longer uses `kubernetes_manifest`, which
+performs a server-side lookup during **plan** and therefore breaks any `terraform plan`
+without cluster access — plan-only CI pipelines in particular.
+
+`moved` blocks cannot express this: they do not support changing resource type. The state
+entry has to be dropped and re-imported.
+
+**Why you cannot skip this:** otherwise Terraform destroys and recreates the ServiceAccount.
+Deleting it invalidates its long-lived token Secret, which is the `token_reviewer_jwt` in
+`vault_kubernetes_auth_backend_config` — Vault Kubernetes auth stops working until a
+subsequent apply repairs it.
+
+For every entry in `k8s_auths`:
+
+```bash
+terraform state rm 'kubernetes_manifest.service_account["<name>"]'
+terraform import 'kubernetes_service_account_v1.vault["<name>"]' '<namespace>/<name>'
+```
+
+Concretely, for `{ name = "certmanager-vault", namespace = "cert-manager", ... }`:
+
+```bash
+terraform state rm 'kubernetes_manifest.service_account["certmanager-vault"]'
+terraform import \
+  'kubernetes_service_account_v1.vault["certmanager-vault"]' \
+  'cert-manager/certmanager-vault'
+```
+
+`terraform state rm` only forgets the resource; it does not touch the cluster. The
+ServiceAccount keeps running throughout.
+
+Then verify:
+
+```bash
+terraform plan
+# expect: No changes, or at most an in-place update
+```
+
+An in-place diff on `automount_service_account_token` is harmless. A **destroy** of the
+ServiceAccount is not — that means the import did not land.
+
+---
+
+### Not affected
+
+`vso.tf` still uses `kubernetes_manifest` for `VaultConnection` and `VaultAuth`. Those are
+gated behind `vso_enabled`, so with the default `vso_enabled = false` there are no
+instances and plan-time cluster access is not required. With `vso_enabled = true` the
+plan-time constraint still applies.

--- a/k8s.tf
+++ b/k8s.tf
@@ -1,23 +1,22 @@
 // CREATE NAMESPACE!?
 
 // CREATE SERVICE-ACCOUNT
-resource "kubernetes_manifest" "service_account" {
+// Deliberately not kubernetes_manifest: that resource performs a server-side
+// lookup during *plan*, so any `terraform plan` without cluster access fails —
+// which rules out plan-only CI pipelines.
+resource "kubernetes_service_account_v1" "vault" {
 
   for_each = {
     for auth in var.k8s_auths :
     auth.name => auth
   }
 
-  manifest = {
-    "apiVersion" = "v1"
-    "kind"       = "ServiceAccount"
-    "metadata" = {
-      "name"      = each.value["name"]
-      "namespace" = each.value["namespace"]
-    }
-
-    "automountServiceAccountToken" = true
+  metadata {
+    name      = each.value["name"]
+    namespace = each.value["namespace"]
   }
+
+  automount_service_account_token = true
 
 }
 
@@ -41,7 +40,7 @@ resource "kubernetes_secret" "vault" {
   type = "kubernetes.io/service-account-token"
 
   depends_on = [
-    kubernetes_manifest.service_account
+    kubernetes_service_account_v1.vault
   ]
 
 }

--- a/kv-mounts.tf
+++ b/kv-mounts.tf
@@ -1,12 +1,28 @@
+locals {
+  // ONE MOUNT PER DISTINCT PATH.
+  // Several secret_engines entries may share a path — that is the whole point of
+  // keying secrets separately below. Deduplicate here, keeping the first entry
+  // seen for a path as the source of its description.
+  kv_mounts = {
+    for path in distinct([for engine in var.secret_engines : engine.path]) :
+    path => [for engine in var.secret_engines : engine if engine.path == path][0]
+  }
+
+  // ONE SECRET PER PATH+NAME.
+  // Keying on path alone made two secrets in the same mount a hard
+  // "Duplicate object key" error, which forced one mount per secret.
+  kv_secrets = {
+    for engine in var.secret_engines :
+    "${engine.path}/${engine.name}" => engine
+  }
+}
+
 # FUNCTION ENABLES KV V2 SECRETS ENGINE
 resource "vault_mount" "kvv2" {
 
-  for_each = {
-    for mount in var.secret_engines :
-    mount.path => mount
-  }
+  for_each = local.kv_mounts
 
-  path = each.value["path"]
+  path = each.key
 
   type        = "kv-v2" # type of backend
   description = each.value["description"]
@@ -17,11 +33,8 @@ resource "vault_mount" "kvv2" {
 resource "vault_generic_secret" "kvv2" {
   depends_on = [vault_mount.kvv2]
 
-  for_each = {
-    for mount in var.secret_engines :
-    mount.path => mount
-  }
+  for_each = local.kv_secrets
 
-  path      = "${each.value["path"]}/${each.value["name"]}"
+  path      = each.key
   data_json = each.value["data_json"]
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
   - Vault Deployment: vault-deployment.md
   - PKI CA with cert-manager: pki-ca.md
   - PKI CA Bootstrap: pki-bootstrap.md
+  - Migration notes: migration.md
 
 plugins:
   - techdocs-core


### PR DESCRIPTION
Addresses **P2.4** and **P2.7** from #46. Both move resources to new state addresses — see the migration section below, and `docs/migration.md`.

## P2.4 — one KV mount could only ever hold one secret

`kv-mounts.tf` keyed both the mount and the secret on `mount.path`, while writing to `${path}/${name}`:

```hcl
for_each = { for mount in var.secret_engines : mount.path => mount }   # both resources
```

Two entries sharing a path were therefore not an unsupported case but a **hard error**:

```
Error: Duplicate object key
  Two different items produced the key "apps" in this 'for' expression.
```

This forces real workarounds. `vault-cicd-secrets` on infra-sthings runs **six separate KV mounts for six secrets**, purely to dodge the collision:

```
vault_mount.kvv2["cicd-vsphere-labda"]      vault_generic_secret.kvv2["cicd-vsphere-labda"]
vault_mount.kvv2["cicd-vsphere-labul"]      vault_generic_secret.kvv2["cicd-vsphere-labul"]
vault_mount.kvv2["cicd-proxmox-labul"]      vault_generic_secret.kvv2["cicd-proxmox-labul"]
vault_mount.kvv2["cicd-kubeconfigs"]        vault_generic_secret.kvv2["cicd-kubeconfigs"]
vault_mount.kvv2["cicd-kubeconfig-labul"]   vault_generic_secret.kvv2["cicd-kubeconfig-labul"]
vault_mount.kvv2["ssh"]                     vault_generic_secret.kvv2["ssh"]
```

Mounts are now derived from the **distinct** paths, and secrets are keyed on `"${path}/${name}"`. `vault_mount` keys are unchanged; only the secret addresses move. Where several entries share a path, the mount `description` comes from the first entry listed for it.

Verified with the exact case that used to fail:

```
mounts (deduplicated):  { "apps": "apps mount", "cicd": "cicd mount" }
secrets:                apps/creds-a, apps/creds-b, cicd/only
```

## P2.7 — `kubernetes_manifest` required a cluster at plan time

The ServiceAccount created for `k8s_auths` used `kubernetes_manifest`, which performs a server-side lookup during **plan**. Any `terraform plan` without cluster access therefore fails, which rules out plan-only CI pipelines. Replaced with `kubernetes_service_account_v1`.

**Partial by design:** `vso.tf` still uses `kubernetes_manifest` for `VaultConnection` and `VaultAuth`. Those are gated via `if var.vso_enabled` inside their `for_each`, so with the default `vso_enabled = false` they produce no instances and impose no plan-time requirement. With `vso_enabled = true` the constraint remains — worth a follow-up, not folded in here.

## Migration — required, not optional

`docs/migration.md` has the full procedure. The short version, and why it cannot be skipped:

**Secrets** — old and new instances resolve to the *same Vault path*. Terraform sees one instance removed and another added with no ordering guarantee between them, so if the destroy runs after the create, **it deletes the secret data it just wrote**. Move them instead:

```bash
terraform state mv \
  'vault_generic_secret.kvv2["<path>"]' \
  'vault_generic_secret.kvv2["<path>/<name>"]'
```

**ServiceAccount** — `moved` blocks cannot express a change of resource type, so the entry has to be dropped and re-imported. Without it Terraform destroys and recreates the ServiceAccount, which invalidates its long-lived token Secret — the `token_reviewer_jwt` in `vault_kubernetes_auth_backend_config` — and Kubernetes auth stops working until a later apply repairs it.

```bash
terraform state rm 'kubernetes_manifest.service_account["<name>"]'
terraform import 'kubernetes_service_account_v1.vault["<name>"]' '<namespace>/<name>'
```

`terraform state rm` only forgets the resource; the cluster is untouched. In both cases the check is the same: **`terraform plan` must show no destroys** before applying.

Collapsing the now-redundant mounts is a *separate* migration and is never required — existing layouts keep working untouched.

## What is verified, and what is not

Verified: the dedup/keying logic against the previously-failing case, `terraform validate`, and repo CI.

**Not verified: the state migration against a real state.** It is derived from the address change and documented carefully, but it has not been executed. Anyone migrating should take a state backup first (`terraform state pull > backup.json`) and stop if the plan shows a destroy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSLXgANJSrsxSevzyH96EZ
